### PR TITLE
Fix tiny casing mistake

### DIFF
--- a/docs/ff-integrations/database/local-sql/quickstart.md
+++ b/docs/ff-integrations/database/local-sql/quickstart.md
@@ -1,6 +1,6 @@
 ---
 slug: /integrations/database/sqlite
-title: SQLIte Quickstart
+title: SQLite Quickstart
 description: Learn how to quickly get started with SQLite in your FlutterFlow app for local data storage.
 tags: [SQLite, Database, Quickstart, Local Storage]
 sidebar_position: 1


### PR DESCRIPTION
### Description
SQLite was spelled SQLIte in the leftnav, so let's fix that.

## Type of change
- [x] Typo fix 
- [ ] New feature 
- [ ] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets



