### PR TITLE
Fix tiny typo in minimum resolution in setup docs

### DIFF
--- a/docs/intro/before-you-begin/setting-up-flutterflow.md
+++ b/docs/intro/before-you-begin/setting-up-flutterflow.md
@@ -16,7 +16,7 @@ You can [**sign up**](https://app.flutterflow.io/create-account) via Apple, Goog
 The FlutterFlow application can be accessed from your browser or installed as a desktop app.
 
 ### General recommendations:
-- Use a screen that is at least **1280 x 1084** 
+- Use a screen that is at least **1280 x 1024** 
 
 ### Browser recommendations:
 - FlutterFlow works best on **Google Chrome** 


### PR DESCRIPTION
### Description

Update minimum resolution in setup page.

1280x1084 is not a [common resolution][1], so probably was meant to be 1280x1024.

[1]: https://en.wikipedia.org/wiki/List_of_common_display_resolutions


## Type of change
- [x] Typo fix 
- [ ] New feature 
- [ ] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets



