### PR TITLE
Library publishing restriction info

### DIFF
--- a/docs/resources/projects/libraries.md
+++ b/docs/resources/projects/libraries.md
@@ -87,8 +87,8 @@ To publish a project as a library, it must meet the following requirements:
 - **No Failed Deployments**: The Publish button remains disabled if a deployment process was started and failed.
 - **No Errors or Warnings**: All project errors or warnings must be addressed beforehand.
 - **Main Branch Only**: You can only publish from the main branch.
-- **Pro Plan Subscription**: A Pro Plan is required to publish a project as a library.
-- **Not Cloned from Marketplace**: The project cannot be a clone of a Marketplace project.
+- **Pro Plan Subscription**: A Pro Plan is required to publish a project as a Library.
+- **Not Cloned from Marketplace**: The project cannot be a clone of a Marketplace item.
 :::
 
 ### Disabled Features in a Library

--- a/docs/resources/projects/libraries.md
+++ b/docs/resources/projects/libraries.md
@@ -80,6 +80,10 @@ To publish a FlutterFlow project as a library, start by creating a FlutterFlow p
 - It's recommended to include a message that tells users what has changed in the version your are publishing.
 :::
 
+:::warning
+You cannot publish a project as a Library if it has already been deployed to the Google Play Store or the Apple App Store. Additionally, the Publish button is disabled if a deployment process was started and failed.
+:::
+
 ### Disabled Features in a Library
 
 When a project is converted into a library, the following features are disabled to ensure compatibility and functionality limitations:

--- a/docs/resources/projects/libraries.md
+++ b/docs/resources/projects/libraries.md
@@ -81,14 +81,14 @@ To publish a FlutterFlow project as a library, start by creating a FlutterFlow p
 :::
 
 :::warning
-You cannot publish a project as a Library if it has already been deployed to the Google Play Store or the Apple App Store. Additionally, the Publish button is disabled if a deployment process was started and failed.
+To publish a project as a library, it must meet the following requirements:
 
-To publish a project as a library, ensure that:
-
-- There are no errors or warnings in the project.
-- The project is on the Main Branch.
-- You have an active Pro Plan subscription.
-- The project is not cloned from a Marketplace project.
+- **No Prior Store Deployment**: The project must not have been deployed to the Google Play Store or Apple App Store.
+- **No Failed Deployments**: The Publish button remains disabled if a deployment process was started and failed.
+- **No Errors or Warnings**: All project errors or warnings must be addressed beforehand.
+- **Main Branch Only**: You can only publish from the main branch.
+- **Pro Plan Subscription**: A Pro Plan is required to publish a project as a library.
+- **Not Cloned from Marketplace**: The project cannot be a clone of a Marketplace project.
 :::
 
 ### Disabled Features in a Library

--- a/docs/resources/projects/libraries.md
+++ b/docs/resources/projects/libraries.md
@@ -82,6 +82,13 @@ To publish a FlutterFlow project as a library, start by creating a FlutterFlow p
 
 :::warning
 You cannot publish a project as a Library if it has already been deployed to the Google Play Store or the Apple App Store. Additionally, the Publish button is disabled if a deployment process was started and failed.
+
+To publish a project as a library, ensure that:
+
+- There are no errors or warnings in the project.
+- The project is on the Main Branch.
+- You have an active Pro Plan subscription.
+- The project is not cloned from a Marketplace project.
 :::
 
 ### Disabled Features in a Library

--- a/firebase.json
+++ b/firebase.json
@@ -2317,6 +2317,11 @@
         "source": "/misc/flutterflow-experts",
         "destination": "/misc/hire-flutterflow-developer",
         "type": 301
+      },
+      {
+        "source": "/firebase-content-manager",
+        "destination": "/integrations/database/cloud-firestore/firestore-content-manager/",
+        "type": 301
       }
     ]
   }


### PR DESCRIPTION
### Description
Library publishing restriction info

[Linear ticket ](https://linear.app/flutterflow/issue/DEVR-719/restrictions-for-already-deployed-project-while-publishing-library)and [magic word](https://linear.app/docs/github#link-prs) Fixes DEVR-719, Fixes DEVR-798

## Type of change
- [ ] Typo fix 
- [ ] New feature 
- [x] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets



