### PR TITLE
Enable Billing for Cloud Storage

### DIFF
--- a/docs/ff-integrations/firebase/connect-to-firebase-setup.md
+++ b/docs/ff-integrations/firebase/connect-to-firebase-setup.md
@@ -168,9 +168,9 @@ com/embed/1abddd1120db477da2c085dbc6b7a742?sid=5b161c8b-3957-4ac9-b27f-dc5ebc03f
 
 
 
-## Enable Billing for Cloud Functions Access
+## Enable Billing
 
-If you want to deploy functions (e.g., Braintree payments, Push Notifications), you will need to enable billing for your Firebase project. Please follow these steps to enable billing:
+If you want to deploy [Cloud Functions](https://firebase.google.com/products/functions) (e.g., Braintree payments, Push Notifications) or create [Firebase Cloud Storage](https://firebase.google.com/products/storage), you will need to enable billing for your Firebase project. Please follow these steps to enable billing:
 
 1. From the Firebase dashboard of your project, navigate to the far left menu. Under Build, select **Functions** and then select **Upgrade project**.
 

--- a/docs/ff-integrations/firebase/connect-to-firebase-setup.md
+++ b/docs/ff-integrations/firebase/connect-to-firebase-setup.md
@@ -170,7 +170,7 @@ com/embed/1abddd1120db477da2c085dbc6b7a742?sid=5b161c8b-3957-4ac9-b27f-dc5ebc03f
 
 ## Enable Billing
 
-If you want to deploy [Cloud Functions](https://firebase.google.com/products/functions) (e.g., Braintree payments, Push Notifications) or create [Firebase Cloud Storage](https://firebase.google.com/products/storage), you will need to enable billing for your Firebase project. Please follow these steps to enable billing:
+If you want to deploy [Cloud Functions](https://firebase.google.com/products/functions) (e.g., Braintree payments, Push Notifications) or use [Firebase Cloud Storage](https://firebase.google.com/products/storage), you will need to enable billing for your Firebase project. Please follow these steps to enable billing:
 
 1. From the Firebase dashboard of your project, navigate to the far left menu. Under Build, select **Functions** and then select **Upgrade project**.
 


### PR DESCRIPTION
### Description
Enable Billing for Cloud Storage

[Linear ticket](https://linear.app/flutterflow/issue/DEVR-654/project-must-be-on-paid-plan-to-create-firebase-cloud-storage) and [magic word](https://linear.app/docs/github#link-prs) Fixes DEVR-654 

## Type of change
- [ ] Typo fix 
- [ ] New feature 
- [x] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets



