### PR TITLE
Fix Typo in Marketplace Doc Url

### DIFF
--- a/docs/marketplace/creators-hub/creators-hub.md
+++ b/docs/marketplace/creators-hub/creators-hub.md
@@ -12,7 +12,7 @@ Welcome to the FlutterFlow Marketplace Creators' Hub! This section is designed t
 
 ### **Submitting an Item for Review**
 - Understand the [criteria](submission-criteria.md) we apply to items submitted to Marketplace.
-- Learn how to prepare and [submit](submit-item-for-reivew.md) your items to the Marketplace with our step-by-step guide.
+- Learn how to prepare and [submit](submit-item-for-review.md) your items to the Marketplace with our step-by-step guide.
 
 ### **Legal Guidelines for Creators**
 

--- a/docs/marketplace/creators-hub/submit-item-for-review.md
+++ b/docs/marketplace/creators-hub/submit-item-for-review.md
@@ -1,5 +1,5 @@
 ---
-slug: submit-item-for-reivew
+slug: submit-item-for-review
 title: Submitting Item for Review
 description: Learn how to submit an item to the FlutterFlow Marketplace.
 tags: [MarketPlace, Creators Hub]

--- a/docs/marketplace/index.md
+++ b/docs/marketplace/index.md
@@ -14,7 +14,7 @@ FlutterFlow's Marketplace is a dynamic platform designed to enhance your app dev
 In the FlutterFlow Marketplace, you can [add and purchase](adding-purchasing-item.md) items to quickly integrate into your projects, significantly reducing development time. The Marketplace is curated to ensure high-quality resources, with contributions from a diverse community of developers and designers.
 
 ## Becoming a Contributor
-If you're interested in contributing to the Marketplace, the [creator hub](creators-hub/creators-hub.md) is your starting point. Here, you can learn about [submitting items for review](creators-hub/submit-item-for-reivew.md), [submission criteria](creators-hub/submission-criteria.md), and [legal guidelines](creators-hub/legal-guidelines-for-creators.md) for creators. Ensuring your submissions adhere to these guidelines helps maintain the quality and integrity of the Marketplace.
+If you're interested in contributing to the Marketplace, the [creator hub](creators-hub/creators-hub.md) is your starting point. Here, you can learn about [submitting items for review](creators-hub/submit-item-for-review.md), [submission criteria](creators-hub/submission-criteria.md), and [legal guidelines](creators-hub/legal-guidelines-for-creators.md) for creators. Ensuring your submissions adhere to these guidelines helps maintain the quality and integrity of the Marketplace.
 
 ## Protecting Your Work
 Understanding and navigating [copyright (DMCA process)](creators-hub/copyright-dmca-process.md) is crucial for both creators and users. The Marketplace provides clear instructions on how to handle copyright issues, ensuring that intellectual property rights are respected.

--- a/firebase.json
+++ b/firebase.json
@@ -1975,7 +1975,7 @@
       },
       {
         "source": "/marketplace/creators-hub/submitting-an-item-for-review",
-        "destination": "/marketplace/creators-hub/submit-item-for-reivew",
+        "destination": "/marketplace/creators-hub/submit-item-for-review",
         "type": 301
       },
       {
@@ -2326,6 +2326,11 @@
       {
         "source": "/concepts/state-management/generated-code",
         "destination": "/generated-code/state-management",
+        "type": 301
+      },
+      {
+        "source": "/marketplace/creators-hub/submit-item-for-reivew",
+        "destination": "/marketplace/creators-hub/submit-item-for-review",
         "type": 301
       }
     ]


### PR DESCRIPTION
### Description
Fix Typo for 'Submitting Item for Review' (Marketplace Doc) Url

[Linear ticket](https://linear.app/flutterflow/issue/DEVR-819/fix-typo-in-documentation-url-path) and [magic word](https://linear.app/docs/github#link-prs) Fixes DEVR-819 

## Type of change
- [x] Typo fix 
- [ ] New feature 
- [ ] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets



