### PR TITLE
Update auth-initial-setup.md

### DIFF
--- a/docs/ff-integrations/authentication/firebase-auth/auth-initial-setup.md
+++ b/docs/ff-integrations/authentication/firebase-auth/auth-initial-setup.md
@@ -155,7 +155,7 @@ While releasing the app, make sure to [**get the key from Play Console**](#getti
 <details>
   <summary>Mac/Linux</summary>
   <div>
-   ```keytool -list -v \ -alias androiddebugkey -keystore ~/.android/debug.keystore``` 
+   ```keytool -list -v -alias androiddebugkey -keystore ~/.android/debug.keystore``` 
   </div>
 </details>
 


### PR DESCRIPTION



### Description
Provide a brief overview of what this documentation update is about. Explain what sections or topics are being added or revised.

The problem is with the \ character. In Linux/macOS, \ is used for line continuation, but in this case, it is unnecessary and could cause issues.

Linear ticket and [magic word](https://linear.app/docs/github#link-prs) Fixes DEVR-XXX  

## Type of change
- [ ] Typo fix 



