### PR TITLE
Fix navigation to the import libraries settings page

### DIFF
--- a/docs/resources/projects/libraries.md
+++ b/docs/resources/projects/libraries.md
@@ -111,7 +111,7 @@ When a project is converted into a library, the following features are disabled 
 
 ## Importing a Library
 
-To import a library project into another FlutterFlow project, you must go to the **Project Dependencies** page in **App Settings**. Here you can specify the library project and version you are importing.
+To import a library project into another FlutterFlow project, you must go **Settings and Integrations** > **Project Setup** > **Project Dependencies** . Here you can specify the library project and version you are importing.
 
 <div style={{
     position: 'relative',


### PR DESCRIPTION
Fix the path to the page where you can import a library, as it's in a different section that what the docs said.


### Description

The documentation said that the Project Dependencies page is under App Settings, but it's actually under Project Setup - so this PR fixes that.


## Type of change
- [x] Typo fix 
- [ ] New feature 
- [ ] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets



