### PR TITLE
docs: fix typos

### DIFF
--- a/docs/ff-concepts/design-system/design-system.md
+++ b/docs/ff-concepts/design-system/design-system.md
@@ -1000,4 +1000,4 @@ If you prefer watching a video tutorial, here's the one for you:
 <details>
 <summary>How is the theme widget different from creating a template and component?</summary>
 <p>The Theme Widget allows you to customize the visual appearance of a single widget, whereas templates consist of multiple widgets that create a unique UI layout with a specific purpose. On the other hand, components are fully-featured custom widgets that combine multiple widgets and actions to complete a task.</p>
-</details> 
+</details>

--- a/docs/ff-concepts/design-system/design-system.md
+++ b/docs/ff-concepts/design-system/design-system.md
@@ -731,7 +731,7 @@ Make sure you have the proper rights or licenses to use the icons in your applic
 
 **Steps to Generate and Add Custom Icons**
 
-1. Head over to the [iconmoon](https://icomoon.io/app/#/select).
+1. Head over to the [icomoon](https://icomoon.io/app/#/select).
 2. Import your custom icon (.svg) or select from the free icons set.
 3. Select the **Generate Font** tab.
 4. Click on the Settings button (gear icon) beside the download text on the bottom right side.

--- a/docs/ff-concepts/design-system/design-system.md
+++ b/docs/ff-concepts/design-system/design-system.md
@@ -1000,4 +1000,4 @@ If you prefer watching a video tutorial, here's the one for you:
 <details>
 <summary>How is the theme widget different from creating a template and component?</summary>
 <p>The Theme Widget allows you to customize the visual appearance of a single widget, whereas templates consist of multiple widgets that create a unique UI layout with a specific purpose. On the other hand, components are fully-featured custom widgets that combine multiple widgets and actions to complete a task.</p>
-</details>
+</details> 

--- a/docs/ff-concepts/design-system/design-system.md
+++ b/docs/ff-concepts/design-system/design-system.md
@@ -731,7 +731,7 @@ Make sure you have the proper rights or licenses to use the icons in your applic
 
 **Steps to Generate and Add Custom Icons**
 
-1. Head over to the [icomoon](https://icomoon.io/app/#/select).
+1. Head over to the [IcoMoon](https://icomoon.io/app/#/select).
 2. Import your custom icon (.svg) or select from the free icons set.
 3. Select the **Generate Font** tab.
 4. Click on the Settings button (gear icon) beside the download text on the bottom right side.

--- a/docs/resources/control-flow/backend-logic/api/rest-api.md
+++ b/docs/resources/control-flow/backend-logic/api/rest-api.md
@@ -343,7 +343,7 @@ Let's see how to get the JSON into the Custom Data Type using an example that fe
 Here's how you do it:
 
 1. First, ensure that you [create a custom data type](#create-custom-data-type-matching-to-json-structure) that matches your JSON structure.
-2. Open your API call definition> **Response & Test tab > Response Type >** enablethe **Parse as 
+2. Open your API call definition > **Response & Test tab > Response Type >** enable the **Parse as 
    Data Type**. Select the **Data Type** that you want to convert into. For this example, it's 'AllProducts'.
 
 ![img_1.png](../imgs/img_1.png)

--- a/docs/resources/projects/libraries.md
+++ b/docs/resources/projects/libraries.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 # Libraries
 
-Libraries enables you to share and reuse entire FlutterFlow projects as dependencies across multiple projects. This allows teams and developers to modularize their apps by creating shared libraries that include components, API calls, custom code, and more. By using libraries, development becomes more efficient and scalable.
+Libraries enable you to share and reuse entire FlutterFlow projects as dependencies across multiple projects. This allows teams and developers to modularize their apps by creating shared libraries that include components, API calls, custom code, and more. By using libraries, development becomes more efficient and scalable.
 
 :::info
 A **Dependency** refers to an external library or resource that your project relies on to function correctly. When you create a new FlutterFlow project, certain dependencies are automatically added to support the generated code. Also, when you use a [**Custom Widget**](../../ff-concepts/adding-customization/custom-widgets.md), you are essentially adding dependencies to your project. Libraries take this concept further by allowing you to add entire FlutterFlow projects as dependencies.


### PR DESCRIPTION
### Description

- 'iconmoon' → 'IcoMoon' in [Design System](https://docs.flutterflow.io/concepts/design-system) section.
- 'enablethe` → 'enable the' in [API Calls](https://github.com/tirth-patel-nc/flutterflow-documentation/blob/patch-1/docs/resources/control-flow/backend-logic/api/rest-api.md) section. 
- 'Libraries enables' → 'Libraries enable' in [Libraries](https://docs.flutterflow.io/resources/projects/libraries) section.

## Type of change
- [x] Typo fix 
- [ ] New feature 
- [x] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets



