### PR TITLE
docs: fix typos

### DIFF
--- a/docs/ff-integrations/authentication/firebase-auth/apple-login.md
+++ b/docs/ff-integrations/authentication/firebase-auth/apple-login.md
@@ -10,7 +10,7 @@ keywords: [FlutterFlow, Apple Login, Authentication, Firebase]
 
 # Apple Login
 
-Apple Sign-In allows users to authenticate using their Apple Accounts.
+Apple Sign-In allow users to authenticate using their Apple Accounts.
 
 :::warning[Support]
 

--- a/docs/ff-integrations/authentication/firebase-auth/google-login.md
+++ b/docs/ff-integrations/authentication/firebase-auth/google-login.md
@@ -9,7 +9,7 @@ keywords: [FlutterFlow, Google OAuth, Authentication, Firebase]
 
 # Google Login
 
-Google Sign-In allows users to authenticate using their Google Accounts.
+Google Sign-In allow users to authenticate using their Google Accounts.
 
 :::info[Prerequisites]
 


### PR DESCRIPTION
### Description

**allows** users -> **allow** users in [Firebase Google OAuth Login](https://docs.flutterflow.io/integrations/authentication/firebase/google-oauth-login) & [Firebase Apple Login](https://docs.flutterflow.io/integrations/authentication/firebase/apple) sections.

## Type of change
- [x] Typo fix 
- [ ] New feature 
- [ ] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets



