### PR TITLE
🧪 Update automated testing limits for Growth

### DIFF
--- a/docs/accounts-billing/new-pricing-comparison.md
+++ b/docs/accounts-billing/new-pricing-comparison.md
@@ -342,7 +342,7 @@ export const PricingToggles = () => {
             <td>Automated Testing<br/><span className="feature-description">Run automated tests on your applications</span></td>
             <td>❌</td>
             <td>❌</td>
-            <td>❌</td>
+            <td>1 test per project</td>
             <td>Up to 3 tests per project</td>
             <td>Unlimited tests</td>
           </tr>


### PR DESCRIPTION
### Description
Changed the automated testing row to reflect '1 test per project' instead of '❌' for the relevant pricing tier in the comparison table.

## Type of change
- [ ] Typo fix 
- [ ] New feature 
- [ ] Enhancement to current docs
- [x] Removed outdated references
- [ ] Update assets



