### PR TITLE
🩺 Add review dispute guidelines to Marketplace docs

### DIFF
--- a/docs/marketplace/creators-hub/review-dispute-guidelines.md
+++ b/docs/marketplace/creators-hub/review-dispute-guidelines.md
@@ -1,0 +1,47 @@
+---
+slug: review-dispute-guidelines
+title: Review Dispute Guidelines
+description: Learn about FlutterFlow Marketplace review dispute process and when reviews may be removed or modified.
+tags: [MarketPlace, Review Dispute, Guidelines]
+sidebar_position: 3
+keywords: [FlutterFlow, MarketPlace, Review Dispute, Guidelines, Feedback, Reviews]
+---
+
+# FlutterFlow Marketplace Review Dispute Guidelines
+
+At FlutterFlow Marketplace, we believe in transparent and honest feedback. Reviews are an essential part of helping buyers make informed decisions and helping creators improve their work.
+
+However, not all reviews are created equal. Sometimes feedback is based on misunderstandings, irrelevant factors, or issues unrelated to the quality of the item itself. This guideline outlines when and how we handle review disputes.
+
+### When We *Will* Remove a Review
+
+We may remove a review if it meets **one or more** of the following criteria:
+
+- **Spam or Abuse:** The review contains offensive language, harassment, or unrelated spam content.
+- **Misuse of the Review System:** The review is about unrelated topics (e.g., FlutterFlow features, pricing, unrelated bugs).
+- **Critical Misunderstanding:** The review is based on a clear misunderstanding of the item's purpose or scope, despite the listing being accurate and transparent.
+- **Irrelevant to the Current Version:** The review references issues that have since been resolved, and the creator has updated the item significantly.  
+    *Note: We may remove outdated reviews in cases where leaving them would misrepresent the current product.*
+
+### When We *Will Not* Remove a Review
+
+We **will not remove** a review just because it is negative if it:
+
+- Represents a real user experience
+- Critiques the item's quality, usability, documentation, or performance in good faith
+- Highlights friction that future buyers may encounter, even if subjective
+
+### How to Dispute a Review
+
+If you believe a review on your item qualifies for removal:
+
+1. **Contact Us:** Email [marketplace@flutterflow.io](mailto:marketplace@flutterflow.io).
+2. **Include:**
+   - A link to the item and review
+   - A short explanation of why you believe it qualifies for removal
+
+Our team will review each case individually and respond within **10 business days**.
+
+### Future Improvements
+
+We are actively working on better creator tools to allow creators to reply directly to reviews.

--- a/docs/marketplace/index.md
+++ b/docs/marketplace/index.md
@@ -4,7 +4,7 @@ title: FlutterFlow Marketplace
 description: Discover how to explore, purchase, and contribute to the FlutterFlow Marketplace, including guidelines for submissions and handling copyrights.
 tags: [Marketplace , Creator Hub]
 sidebar_position: 0
-keywords: [FlutterFlow, Marketplace, Add and Purchase Items, Refund Policy, Submit Feedback, Creator Hub, Submission Criteria, Legal Guidelines, Copyright, DMCA Process, External Licensing, Creators FAQs]
+keywords: [FlutterFlow, Marketplace, Add and Purchase Items, Refund Policy, Submit Feedback, Review Dispute Guidelines, Creator Hub, Submission Criteria, Legal Guidelines, Copyright, DMCA Process, External Licensing, Creators FAQs]
 ---
 
 # FlutterFlow Marketplace
@@ -20,6 +20,14 @@ If you're interested in contributing to the Marketplace, the [creator hub](creat
 Understanding and navigating [copyright (DMCA process)](creators-hub/copyright-dmca-process.md) is crucial for both creators and users. The Marketplace provides clear instructions on how to handle copyright issues, ensuring that intellectual property rights are respected.
 
 For those dealing with third-party resources, [navigating external licensing](creators-hub/navigating-external-licenses.md) is essential. The Marketplace offers guidelines to help you understand and comply with various licensing agreements.
+
+## Marketplace Policies and Guidelines
+
+Understanding our marketplace policies helps ensure a positive experience for all users:
+
+- [Refund Policy](refund-policy.md) - Learn about our refund policy and exceptional circumstances
+- [Review Dispute Guidelines](creators-hub/review-dispute-guidelines.md) - Understanding when and how reviews may be disputed
+- [Submit Feedback](submit-feedback.md) - Learn how to rate items and provide feedback
 
 ## FAQs
 Our [Creators FAQs](creators-hub/creators-hub.md) section provides answers to common questions, supporting you throughout your journey in the Marketplace.

--- a/docs/marketplace/submit-feedback.md
+++ b/docs/marketplace/submit-feedback.md
@@ -4,7 +4,7 @@ title: Submit Feedback
 description: Learn more about the submitting feedback on FlutterFlow marketplace items.
 tags: [MarketPlace, Submit Feedback]
 sidebar_position: 2
-keywords: [FlutterFlow, MarketPlace, Submit Feedback]
+keywords: [FlutterFlow, MarketPlace, Submit Feedback, Review Dispute Guidelines]
 ---
 
 # Submitting Feedback for Items
@@ -57,3 +57,7 @@ If you encounter any issues with an item that may require our attention, such as
 :::tip
 If you are the original author or copyright holder of content that has been uploaded to the FlutterFlow Marketplace without your permission, you can file DMCA takedown request following the instructions in [**FlutterFlow's Terms of Service**](https://flutterflow.io/tos).
 :::
+
+## Review Disputes
+
+If you're a creator and believe a review on your item was submitted inappropriately, you can learn about our review dispute process in our [Review Dispute Guidelines](creators-hub/review-dispute-guidelines.md). This covers when reviews may be removed and how to submit a dispute.


### PR DESCRIPTION
### Description
Introduced a new 'Review Dispute Guidelines' page outlining when reviews may be removed or retained, and how creators can dispute reviews. Updated 'index.md' and 'submit-feedback.md' to reference the new guidelines and provide clearer navigation for marketplace policies.


Linear ticket and [magic word](https://linear.app/docs/github#link-prs) Fixes MKT-585

## Type of change
- [ ] Typo fix 
- [ ] New feature 
- [x] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets



