### PR TITLE
added some padding between chatbot icon and corner of the screen

### DIFF
--- a/src/js/chatbot.js
+++ b/src/js/chatbot.js
@@ -18,11 +18,11 @@
   style.textContent = `
     #dify-chatbot-bubble-button {
       background-color: #4B39EF !important;
-      bottom: 0.25rem !important;
-      right: 0.25rem !important;
+      bottom: 0.80rem !important;
+      right: 0.80rem !important;
       border-radius: 50% !important;
-      width: 50px !important;
-      height: 50px !important;
+      width: 45px !important;
+      height: 45px !important;
     }
     
     /* Make the main chat window background more translucent to show rounded corners */


### PR DESCRIPTION
Increased padding between the chatbot icon and corner of the screen

<img width="1664" height="946" alt="Screenshot 2025-07-28 at 2 16 12 PM" src="https://github.com/user-attachments/assets/e49365dd-66f2-436d-bc2b-0348d40a1f78" />

