### PR TITLE
Fix "usecases" typo in tip admonitions

### DIFF
--- a/docs/resources/projects/libraries.md
+++ b/docs/resources/projects/libraries.md
@@ -27,7 +27,7 @@ Previously, FlutterFlow offered several methods to share resources between proje
 
 With Libraries, you can publish the complete FlutterFlow project as a library and import it as a dependency into other projects.
 
-:::tip[possible usecases]
+:::tip[possible use cases]
 
 - **Modular Development**: Build large-scale apps by separating them into smaller, independently managed projects (e.g., UI library, backend integrations, etc.).
 - **Team Collaboration**: Share reusable UI components, custom functions, or API integrations across multiple apps within a team.

--- a/docs/resources/ui/pages/page-lifecycle.md
+++ b/docs/resources/ui/pages/page-lifecycle.md
@@ -99,7 +99,7 @@ trigger specific actions in response to a phone shake gesture.
 
 This action trigger lets you bind keyboard shortcuts to actions. This is incredibly helpful for improving accessibility and enhancing user experience, especially in web and desktop apps.
 
-:::tip[Possible usecases]
+:::tip[Possible use cases]
 
 - **Create New Issues in Project Management Apps:** In project management apps like Linear, users can press `C` to quickly open a form for creating a new issue or task.
 - **Form Submission:** Users can press a key combination (e.g., `Ctrl + Enter`) to submit a form.


### PR DESCRIPTION
## Description
Fixes a small spelling typo: **"usecases" → "use cases"** in the two `:::tip[…]` admonition titles where it appears.

- `docs/resources/ui/pages/page-lifecycle.md` — `:::tip[Possible usecases]`
- `docs/resources/projects/libraries.md` — `:::tip[possible usecases]`

Follow-up nit spotted while reviewing #530 / #529.

## Type of change
- [x] Typo fix
- [ ] New feature
- [ ] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)